### PR TITLE
Update for depreciated ReactChild

### DIFF
--- a/frontend/components/Input/Input.tsx
+++ b/frontend/components/Input/Input.tsx
@@ -2,7 +2,7 @@ import {
   FC,
   ChangeEventHandler,
   InputHTMLAttributes,
-  ReactChild,
+  ReactElement,
   forwardRef,
   ForwardedRef,
 } from "react";
@@ -104,7 +104,7 @@ export type Props = {
   /** Icon */
   icon?: AvailableIcons;
   /** Feedback for input */
-  feedback?: ReactChild;
+  feedback?: ReactElement | string;
 } & WrapperProps;
 
 export const Input: FC<Props & InputHTMLAttributes<HTMLInputElement>> =


### PR DESCRIPTION
ReactChild used in Input.tsx gave a notice of depreciation and suggested using ReactElement instead. Updating the type to be ReactElement | string made it so there are no errors on the Input.stories.ts file.